### PR TITLE
Fix extraction of minutes when there are 3 digits for degrees

### DIFF
--- a/mgrs/__init__.py
+++ b/mgrs/__init__.py
@@ -67,11 +67,11 @@ class MGRS:
         divisor = 3600.0
         if len(pieces) == 1:
             S = dms[-2:]
-            M = dms[2:-2]
+            M = dms[-4:-2]
             D = dms[:-4]
         else:
             S = '{0:s}.{1:s}'.format (pieces[0][-2:], pieces[1])
-            M = pieces[0][2:-2]
+            M = pieces[0][-4:-2]
             D = pieces[0][:-4]
 
         DD = float(D) + float(M)/60.0 + float(S)/divisor


### PR DESCRIPTION
When the degrees of longitude reach 3 digits, the dmstodd() method gives incorrect results because the digits representing the minutes are extracted using a 2-character offset relative to the start of the string. This is fixed by changing [2:-2] to [-4:-2] in two places in dmstodd() so that the two digits representing the minutes are extracted relative to the end of the string, not the beginning