### PR TITLE
Ignore conversion warnings generated by libmgrs

### DIFF
--- a/mgrs/core.py
+++ b/mgrs/core.py
@@ -203,7 +203,7 @@ def TO_DEGREES(radians):
 
 def check_error(result, func, cargs):
     "Error checking proper value returns"
-    if result != 0:
+    if result in errors:
         msg = 'Error in "%s": %s' % (func.__name__, get_errors(result))
         raise MGRSError(msg)
     return

--- a/mgrs/core.py
+++ b/mgrs/core.py
@@ -18,7 +18,7 @@ class DeprecatedClassMeta(type):
     """
 
     def __new__(cls, name, bases, classdict, *args, **kwargs):
-        
+
         alias = classdict.get("_DeprecatedClassMeta__alias")
 
         if alias is not None:
@@ -188,12 +188,14 @@ warnings = {
     0x0400: "Latitude Warning",
 }
 
+
 def get_errors(value):
     output = []
     for key in errors.keys():
         if key & value:
             output.append(errors[key])
     return " & ".join(output)
+
 
 def get_warnings(value):
     output = []
@@ -211,22 +213,24 @@ def TO_DEGREES(radians):
     return float(radians) * 180.0 / math.pi
 
 
-# Report all runtime warnings from this module, not only the first time (default)
+# Report all runtime warnings from this module, not only the first (default)
 filterwarnings("always", category=RuntimeWarning, module="mgrs")
+
 
 def check_error(result, func, cargs):
     "Error checking proper value returns"
-    if result != 0:
-        _errors = get_errors(result)
-        if _errors:
-            raise MGRSError(f'Error in "{func.__name__}": {_errors}')
-        _warnings = get_warnings(result)
-        if _warnings:
-            warn(
-                f'Warning in "{func.__name__}": {_warnings} using args: {cargs}',
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
+    if result == 0:
+        return
+    _errors = get_errors(result)
+    if _errors:
+        raise MGRSError(f'Error in "{func.__name__}": {_errors}')
+    _warnings = get_warnings(result)
+    if _warnings:
+        warn(
+            f'Warning in "{func.__name__}": {_warnings} using args: {cargs}',
+            category=RuntimeWarning,
+            stacklevel=2,
+        )
     return
 
 

--- a/mgrs/core.py
+++ b/mgrs/core.py
@@ -3,6 +3,7 @@ import math
 import os
 import sysconfig
 from ctypes.util import find_library
+from warnings import filterwarnings, warn
 
 import packaging.tags
 
@@ -17,8 +18,7 @@ class DeprecatedClassMeta(type):
     """
 
     def __new__(cls, name, bases, classdict, *args, **kwargs):
-        from warnings import warn
-
+        
         alias = classdict.get("_DeprecatedClassMeta__alias")
 
         if alias is not None:
@@ -184,13 +184,23 @@ errors = {
     0x0200: "Hemisphere Error",
 }
 
+warnings = {
+    0x0400: "Latitude Warning",
+}
 
 def get_errors(value):
-    output = "MGRS Errors: "
+    output = []
     for key in errors.keys():
         if key & value:
-            output += errors[key] + " & "
-    return output[:-2]
+            output.append(errors[key])
+    return " & ".join(output)
+
+def get_warnings(value):
+    output = []
+    for key in warnings.keys():
+        if key & value:
+            output.append(warnings[key])
+    return " & ".join(output)
 
 
 def TO_RADIANS(degrees):
@@ -201,11 +211,22 @@ def TO_DEGREES(radians):
     return float(radians) * 180.0 / math.pi
 
 
+# Report all runtime warnings from this module, not only the first time (default)
+filterwarnings("always", category=RuntimeWarning, module="mgrs")
+
 def check_error(result, func, cargs):
     "Error checking proper value returns"
-    if result in errors:
-        msg = 'Error in "%s": %s' % (func.__name__, get_errors(result))
-        raise MGRSError(msg)
+    if result != 0:
+        _errors = get_errors(result)
+        if _errors:
+            raise MGRSError(f'Error in "{func.__name__}": {_errors}')
+        _warnings = get_warnings(result)
+        if _warnings:
+            warn(
+                f'Warning in "{func.__name__}": {_warnings} using args: {cargs}',
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
     return
 
 

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -72,8 +72,12 @@
 
 >>> coords = "50TMK5045027900"
 >>> convert.toLatLon(coords)
+/usr/local/lib/python3.11/site-packages/oms/mgrs/__init__.py:103: RuntimeWarning: Warning in "Convert_MGRS_To_Geodetic": Latitude Warning using args: (b'50TMK5045027900', <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6cf80>, <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6d2e0>)
+  core.rt.Convert_MGRS_To_Geodetic(c, plat, plon)
 (39.999832750881616, 116.41951845782629)
 
 >>> coords = "32TNK0000000000"
 >>> convert.toLatLon(coords)
+/usr/local/lib/python3.11/site-packages/oms/mgrs/__init__.py:103: RuntimeWarning: Warning in "Convert_MGRS_To_Geodetic": Latitude Warning using args: (b'32TNK0000000000', <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6d2e0>, <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6cf80>)
+  core.rt.Convert_MGRS_To_Geodetic(c, plat, plon)
 (39.7499075191044, 9.0)

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -66,3 +66,14 @@
 
 >>> convert.UTMToMGRS(15,'N',580817,4251205)
 '15SWC8081751205'
+
+>>> # These two MGRS coordinates produce a warning in libmgrs (see issue #45)
+>>> convert = mgrs.MGRS()
+
+>>> coords = "50TMK5045027900"
+>>> convert.toLatLon(coords)
+(39.999832750881616, 116.41951845782629)
+
+>>> coords = "32TNK0000000000"
+>>> convert.toLatLon(coords)
+(39.7499075191044, 9.0)

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -72,12 +72,8 @@
 
 >>> coords = "50TMK5045027900"
 >>> convert.toLatLon(coords)
-/usr/local/lib/python3.11/site-packages/oms/mgrs/__init__.py:103: RuntimeWarning: Warning in "Convert_MGRS_To_Geodetic": Latitude Warning using args: (b'50TMK5045027900', <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6cf80>, <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6d2e0>)
-  core.rt.Convert_MGRS_To_Geodetic(c, plat, plon)
 (39.999832750881616, 116.41951845782629)
 
 >>> coords = "32TNK0000000000"
 >>> convert.toLatLon(coords)
-/usr/local/lib/python3.11/site-packages/oms/mgrs/__init__.py:103: RuntimeWarning: Warning in "Convert_MGRS_To_Geodetic": Latitude Warning using args: (b'32TNK0000000000', <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6d2e0>, <oms.mgrs.core.LP_c_double object at 0x7fc7e9a6cf80>)
-  core.rt.Convert_MGRS_To_Geodetic(c, plat, plon)
 (39.7499075191044, 9.0)


### PR DESCRIPTION
When converting certain MGRS coordinates to (latitude, longitude), `libmgrs` produces the expected output but also returns an error code that denotes a warning.

The warnings were interpreted as errors and `mgrs.core.MGRSError` errors were raised.

The warnings are now ignored.

Fixes: #45 